### PR TITLE
[ENG-24939] - Added Parameters to Resource Action Client

### DIFF
--- a/cbclient/action_client.go
+++ b/cbclient/action_client.go
@@ -7,12 +7,16 @@ import (
 )
 
 // SubmitAction runs an action on the CloudBolt resource or server
-func (c *CloudBoltClient) SubmitAction(actionPath string, resourcePath string) (*CloudBoltJob, error) {
+func (c *CloudBoltClient) SubmitAction(actionPath string, resourcePath string, parameters map[string]interface{}) (*CloudBoltJob, error) {
 	apiurl := c.baseURL
 	apiurl.Path = fmt.Sprintf("%srunAction/", actionPath)
 
 	reqData := map[string]interface{}{
 		"resource": resourcePath,
+	}
+
+	if parameters != nil {
+		reqData["parameters"] = parameters
 	}
 
 	reqJSON, err := json.Marshal(reqData)


### PR DESCRIPTION
The resource action client now accepts a set of name/value pairs for the resource action parameters, these parameters are now passed when invoking the CB resource action.